### PR TITLE
Fix app name and other .desktop file metadata

### DIFF
--- a/com.endlessnetwork.passage.desktop
+++ b/com.endlessnetwork.passage.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=The Passage
-Comment=A game where you learn programming by hacking different elements.
+Comment=Hack your way through this side scrolling action adventure shooting game
 Exec=com.endlessnetwork.passage.sh
 Icon=com.endlessnetwork.passage
 Terminal=false

--- a/com.endlessnetwork.passage.desktop
+++ b/com.endlessnetwork.passage.desktop
@@ -5,4 +5,4 @@ Exec=com.endlessnetwork.passage.sh
 Icon=com.endlessnetwork.passage
 Terminal=false
 Type=Application
-Categories=Game;X-LearnToCode;
+Categories=Game;

--- a/com.endlessnetwork.passage.desktop
+++ b/com.endlessnetwork.passage.desktop
@@ -1,9 +1,8 @@
 [Desktop Entry]
-Name=passage
+Name=The Passage
 Comment=A game where you learn programming by hacking different elements.
 Exec=com.endlessnetwork.passage.sh
 Icon=com.endlessnetwork.passage
 Terminal=false
 Type=Application
 Categories=Game;X-LearnToCode;
-Name[en_US]=com.endlessnetwork.passage


### PR DESCRIPTION
Currently, on an en_US system, the desktop icon is labelled "com.endlessnetwork.passage", and on other systems it is labelled "passage". 35d2f3292c8c19d070ae3472d5efa89ce07bb10d changed the name in the appdata to "The Passage" so let's make this one match.

Also address some other issues in the .desktop file.

https://phabricator.endlessm.com/T25937#702712